### PR TITLE
Remove Fabric  traces

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,9 +26,5 @@
         <activity
             android:name="com.pithsoftware.wifipasswords.activities.PasscodeActivity"
             android:label="@string/activity_title_passcode" />
-
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="06f213f31a8be7b286366ad575d0b66761422192" />
     </application>
 </manifest>


### PR DESCRIPTION
Fabric was removed in previous commit,
See https://github.com/David-Mawer/OreoWifiPasswords/commit/3429568b056b2149de15ef6c7e0310c8e87088a3